### PR TITLE
Indent headings by level in symbol list

### DIFF
--- a/Symbols.tmPreferences
+++ b/Symbols.tmPreferences
@@ -2,11 +2,20 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>entity.name.section.typst</string>
+    <string>text.typst markup.heading - meta.whitespace.newline</string>
     <key>settings</key>
     <dict>
         <key>showInSymbolList</key>
         <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string><![CDATA[
+            s/^\s*={6,}\s*/          /g;
+            s/^\s*={5}\s*/        /g;
+            s/^\s*={4}\s*/      /g;
+            s/^\s*={3}\s*/    /g;
+            s/^\s*={2}\s*/  /g;
+            s/^\s*={1}\s*//g;
+        ]]></string>
     </dict>
 </dict>
 </plist>

--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -98,7 +98,8 @@ contexts:
   heading-content:
     - meta_scope: markup.heading.typst
     - meta_content_scope: entity.name.section.typst
-    - match: $\n?
+    - match: \s*$\n?
+      scope: meta.whitespace.newline.typst
       pop: true
     - include: inlines
 

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -1,4 +1,4 @@
-// SYNTAX TEST partial-symbols "Packages/Typst/Typst.sublime-syntax"
+// SYNTAX TEST "Packages/Typst/Typst.sublime-syntax"
 
 // foo
 // ^ comment.line.double-dash
@@ -11,7 +11,7 @@
 // ^ markup.heading.typst - punctuation
  // <- - entity.name.section
 //^^^^^^^ entity.name.section.typst
-//@@@@@@@ local-definition
+//       ^ meta.whitespace.newline.typst
 
   - foo
     - bar


### PR DESCRIPTION
See https://github.com/hyrious/typst-syntax-highlight/pull/9#issuecomment-1636819507

Inspired by the Markdown syntax: https://github.com/sublimehq/Packages/blob/master/Markdown/Symbol%20List%20-%20Heading.tmPreferences

It looks like the symbolTransformation messes with ST's symbol tests, so I removed that part from the syntax tests again.