### PR TITLE
Bail out of math mode on dollar sign

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -896,6 +896,8 @@ contexts:
       push: math-bracket-content
 
   math-bracket-content:
+    - match: (?=\$)
+      pop: true
     - match: (\))
       captures:
         1: constant.character.parenthesis.typst
@@ -904,6 +906,8 @@ contexts:
     - include: script-symbols
 
   math-function-params:
+    - match: (?=\$)
+      pop: true
     - match: (\))
       captures:
         1: punctuation.section.group.end.typst

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -62,6 +62,11 @@ $ sin pi => 0 $
 //            ^ markup.math.typst punctuation.definition.math.end.typst
 // <- markup.math.typst punctuation.definition.math.begin.typst - markup.math markup.math
 
+$ ( $
+//   ^ - markup.math
+$ frac(1, 2 $
+//           ^ - markup.math
+
 // #5
 #box()[
   #table( columns:(1fr,auto,auto),


### PR DESCRIPTION
This example compiles fine, but highlighting "breaks" for the rest of the file:
```typst
$ ( $

= Heading

Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
```

(The 2nd example in the syntax tests is frankly a syntax error, but it's still better if highlighting wouldn't break.)