### PR TITLE
Add meta scope for function call params

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -1086,6 +1086,7 @@ contexts:
       push: content-block-content
 
   script-function-params:
+    - meta_scope: meta.function-call.arguments.typst
     - match: (\))
       captures:
         1: punctuation.section.group.end.typst

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -83,6 +83,11 @@ for should not be highlighted here
 //           ^ punctuation.definition.string.begin.typst
 //               ^ punctuation.definition.string.end.typst
 
+#set heading(numbering: "I.")
+//          ^^^^^^^^^^^^^^^^^ meta.function-call.arguments.typst
+#lorem(30)
+//    ^^^^ meta.function-call.arguments.typst
+
 // The doc on official readme.
 #set page(width: 10cm, height: auto)
 #set heading(numbering: "1.")


### PR DESCRIPTION
This allows LSPs signature help popup to stay open while typing the parameters, for example.