### PR TITLE
Improve number scopes

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -916,16 +916,32 @@ contexts:
     - include: script-symbols
 
   math-numerics:
-    - match: (\d*)?\.?\d+([eE][-+]?\d+)?(%)
-      scope: constant.numeric.typst
+    - match: \b(0x)(\h+)
+      scope: meta.number.integer.hexadecimal.typst
       captures:
-        3: constant.numeric.suffix.typst
-    - match: (\d*)?\.?\d+([eE][-+]?\d+)?(mm|pt|cm|in|em|rad|deg|fr)?\b
-      scope: constant.numeric.typst
+        1: constant.numeric.base.typst
+        2: constant.numeric.value.typst
+    - match: \b(0o)([0-7]+)
+      scope: meta.number.integer.octal.typst
       captures:
+        1: constant.numeric.base.typst
+        2: constant.numeric.value.typst
+    - match: \b(0b)([01]+)
+      scope: meta.number.integer.binary.typst
+      captures:
+        1: constant.numeric.base.typst
+        2: constant.numeric.value.typst
+    - match: (\d*(\.)\d+(?:[eE][-+]?\d+)?|\d+[eE][-+]?\d+)(%|(?:pt|mm|cm|in|em|deg|rad|fr)\b)?
+      scope: meta.number.float.decimal.typst
+      captures:
+        1: constant.numeric.value.typst
+        2: punctuation.separator.decimal.typst
         3: constant.numeric.suffix.typst
-    - match: (0x[0-9a-zA-Z]+|(0b|0o)?\d+)\b
-      scope: constant.numeric.typst
+    - match: \b(\d+)(%|(?:pt|mm|cm|in|em|deg|rad|fr)\b)?
+      scope: meta.number.integer.decimal.typst
+      captures:
+        1: constant.numeric.value.typst
+        2: constant.numeric.suffix.typst
 
   math-symbols:
     - match: '{{math_symbol_shorthands}}'

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -53,12 +53,86 @@ console.log(1)
 link: https://example.org?a=%20b
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^ markup.underline.link.typst
 
+ #1
+//^ meta.number.integer.decimal.typst constant.numeric.value.typst
+
+ #0xff
+//^^^^ meta.number.integer.hexadecimal.typst
+//^^ constant.numeric.base.typst
+//  ^^ constant.numeric.value.typst
+
+ #0o10
+//^^^^ meta.number.integer.octal.typst
+//^^ constant.numeric.base.typst
+//  ^^ constant.numeric.value.typst
+
+ #0b1001
+//^^^^^^ meta.number.integer.binary.typst
+//^^ constant.numeric.base.typst
+//  ^^^^ constant.numeric.value.typst
+
+ #3.14
+//^^^^ meta.number.float.decimal.typst constant.numeric.value.typst
+// ^ punctuation.separator.decimal.typst
+
+ #1e4
+//^^^ meta.number.float.decimal.typst constant.numeric.value.typst
+
+#rect(width: 72pt)
+//           ^^^^ meta.number.integer.decimal.typst
+//           ^^ constant.numeric.value.typst
+//             ^^ constant.numeric.suffix.typst
+
+#rect(width: 254mm)
+//           ^^^^^ meta.number.integer.decimal.typst
+//           ^^^ constant.numeric.value.typst
+//              ^^ constant.numeric.suffix.typst
+
+#rect(width: 2.54cm)
+//           ^^^^^^ meta.number.float.decimal.typst
+//           ^^^^ constant.numeric.value.typst
+//            ^ punctuation.separator.decimal.typst
+//               ^^ constant.numeric.suffix.typst
+
+#rect(width: 1in)
+//           ^^^ meta.number.integer.decimal.typst
+//           ^ constant.numeric.value.typst
+//            ^^ constant.numeric.suffix.typst
+
+#rect(width: 2.5em)
+//           ^^^^^ meta.number.float.decimal.typst
+//           ^^^ constant.numeric.value.typst
+//            ^ punctuation.separator.decimal.typst
+//              ^^ constant.numeric.suffix.typst
+
+#rotate(180deg)[Hello there!]
+//      ^^^^^^ meta.number.integer.decimal.typst
+//      ^^^ constant.numeric.value.typst
+//         ^^^ constant.numeric.suffix.typst
+
+#rotate(3.14rad)[Hello there!]
+//      ^^^^^^^ meta.number.float.decimal.typst
+//      ^^^^ constant.numeric.value.typst
+//       ^ punctuation.separator.decimal.typst
+//          ^^^ constant.numeric.suffix.typst
+
+#scale(x: 150%)[Scaled apart.]
+//        ^^^^ meta.number.integer.decimal.typst
+//        ^^^ constant.numeric.value.typst
+//           ^ constant.numeric.suffix.typst
+
+Left #h(1fr) Left-ish #h(2fr) Right
+//      ^^^ meta.number.integer.decimal.typst
+//      ^ constant.numeric.value.typst
+//       ^^ constant.numeric.suffix.typst
+
+
 $ sin pi => 0 $
 //^^^^^^^^^^^^^ markup.math.typst
 //^^^ support.function.math.typst
 //    ^^ keyword.other.greek.math.typst
 //       ^^ constant.other.typst
-//          ^ constant.numeric.typst
+//          ^ constant.numeric.value.typst
 //            ^ markup.math.typst punctuation.definition.math.end.typst
 // <- markup.math.typst punctuation.definition.math.begin.typst - markup.math markup.math
 


### PR DESCRIPTION
This should update the scopes for numbers to the latest conventions, and fixes a stacking of `constant.numeric.typst constant.numeric.suffix.typst` scopes.