### PR TITLE
Improve auto indentation in expressions

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -90,5 +90,32 @@
       { "key": "preceding_text", "operator": "regex_contains", "operand": "`$", "match_all": true },
       { "key": "following_text", "operator": "regex_contains", "operand": "^`", "match_all": true }
     ]
-  }
+  },
+
+  // Add indented line in parentheses
+  {
+    "keys": ["enter"],
+    "command": "insert_snippet",
+    "args": { "contents": "\n\t$0\n" },
+    "context": [
+      { "key": "setting.auto_indent" },
+      { "key": "selector", "operand": "text.typst meta.expression", "match_all": true },
+      { "key": "selection_empty", "match_all": true },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "\\($", "match_all": true },
+      { "key": "following_text", "operator": "regex_contains", "operand": "^\\)", "match_all": true }
+    ]
+  },
+  // Add indented line in square brackets
+  {
+    "keys": ["enter"],
+    "command": "insert_snippet",
+    "args": { "contents": "\n\t$0\n" },
+    "context": [
+      { "key": "setting.auto_indent" },
+      { "key": "selector", "operand": "text.typst meta.expression", "match_all": true },
+      { "key": "selection_empty", "match_all": true },
+      { "key": "preceding_text", "operator": "regex_contains", "operand": "\\[$", "match_all": true },
+      { "key": "following_text", "operator": "regex_contains", "operand": "^\\]", "match_all": true }
+    ]
+  },
 ]

--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -836,13 +836,13 @@ contexts:
     - match: (#)(?!{{prefixes}})({{identifier}}(?:(\.){{identifier}})*)(?=[\[\(])
       scope: support.other.typst variable.function.typst
       captures:
-        1: punctuation.definition.variable.typst
+        1: punctuation.definition.expression.typst
         3: punctuation.accessor.typst
       push: script-function-content
     - match: (#)(?!{{prefixes}})({{identifier}}(?:(\.){{identifier}})*)
-      scope: constant.other.symbol.typst
+      scope: meta.expression.typst constant.other.symbol.typst
       captures:
-        1: punctuation.definition.variable.typst
+        1: punctuation.definition.expression.typst
         3: punctuation.accessor.typst
     - match: '{{markup_symbol_shorthands}}'
       scope: constant.other.typst
@@ -953,21 +953,21 @@ contexts:
   scripts:
     - match: (#)(?={{prefixes}})
       captures:
-        1: punctuation.definition.script.begin.typst
+        1: punctuation.definition.expression.typst
       push: script-statement
     - match: '#'
-      scope: punctuation.definition.script.begin.typst
+      scope: punctuation.definition.expression.typst
       push: script-expression
 
   script-statement:
-    - meta_scope: markup.other.typst
+    - meta_scope: meta.expression.typst
     - match: $\n?
       #      ^ TODO: this is incorrect, but matching a random "expression" is also hard..
       pop: true
     - include: script-common
 
   script-expression:
-    - meta_scope: markup.other.typst
+    - meta_scope: meta.expression.typst
     - match: (?=[\s\]])
       #      ^ stop scripting when seeing space or ], maybe wrong
       pop: true
@@ -1066,6 +1066,7 @@ contexts:
       pop: true
 
   script-function-content:
+    - meta_scope: meta.expression.typst
     - match: \(
       scope: punctuation.section.group.begin.typst
       push: script-function-params

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -80,8 +80,8 @@ $ frac(1, 2 $
 for should not be highlighted here
 
   #let foo = "bar"
-//^^^^^^^^^^^^^^^^ markup.other.typst
-//^ punctuation.definition.script.begin.typst
+//^^^^^^^^^^^^^^^^ meta.expression.typst
+//^ punctuation.definition.expression.typst
 // ^^^ storage.type.typst
 //         ^ keyword.operator.typst
 //           ^^^^^ string.quoted.double.typst


### PR DESCRIPTION
This is a suggestion to improve the auto-indentation behavior while typing in scripting functions / expressions. If you press <kbd>Enter</kbd> when the cursor is inside of `()` or `[]`, it will add another line and an indentation level. This is similar to the built-in behavior in the JSON syntax when you press <kbd>Enter</kbd> with the cursor inside of `[]`.

I adjusted the scope for the `#` symbol and the scope for expressions from `markup.other` to `meta.expression`, because it's not really markup (unlike the math environment, which does get printed to the document). Maybe it can be improved later for the `[ ... ]` content blocks, which contain the markup / printed text, and therefore probably should get a different scope.