### PR TITLE
Don't treat dash in kebab-case as operator

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -22,7 +22,7 @@ variables:
   greeks: (alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|iota|gamma|kappa|lambda|mu|nu|xi|pi|varpi|rho|varrho|sigma|varsigma|tau|upsilon|phi|varphi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)
   non_raw_ident: '[[:alpha:]][-_[:alnum:]]*|_[-_[:alnum:]]+'
   identifier: '(?:{{non_raw_ident}})'
-  operators: ([-+*/]=?|=>|==?|[<>]=?|\bin\b|\bnot\s+in\b|\bnot\b|\band\b|\bor\b)
+  operators: ([+*/]=?|\B-=?|=>|==?|[<>]=?|\bin\b|\bnot\s+in\b|\bnot\b|\band\b|\bor\b)
   prefixes: (?:(?:include|import|set|let|if|for|while|show)\b)
   not_begin_of_emph: '[a-zA-Z0-9]'
   not_end_of_emph: '[a-zA-Z0-9]'


### PR DESCRIPTION
Before: The dash in kebab-case variables was scoped as `keyword.operator.typst`.
After: in script mode, `a-b` and `a-` are treated as identifiers, and `-a` as unary minus.

Not sure if this is the best way to fix this, and I haven’t added any associated tests — not sure how.