### PR TITLE
Allow `\"` within strings

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -1128,7 +1128,7 @@ contexts:
   string-content:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.typst
-    - match: '"'
+    - match: '(?<!\\)"'
       scope: punctuation.definition.string.end.typst
       pop: true
 


### PR DESCRIPTION
This stops strings being terminated on an escaped quote.

Sorry, was too annoying to figure out how to merge this with my previous PR from the browser editor!