### PR TITLE
Fix matching end of string `string-content` (again)

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -1143,7 +1143,8 @@ contexts:
   string-content:
     - meta_include_prototype: false
     - meta_scope: string.quoted.double.typst
-    - match: '(?<!\\)"'
+    - match: '\\.'
+    - match: '"'
       scope: punctuation.definition.string.end.typst
       pop: true
 


### PR DESCRIPTION
Properly handle backslashes. Before, strings such as `"\\\\"` (representing `\\`) did not close as expected.
(And who is to blame? Actually, it was me from months ago!)

Now, the following is parsed correctly:
```typ
#let x = f("hello", 1)
#let x = f("\"", 1)
#let x = f("she said \"cool\"", 1)
#let x = f("\\", 1)
#let x = f("\\\"", 1)
#let x = f("\\\\", 1)
#let x = f("\\\\\\", 1)
#let x = f("\"\"", 1)
#let x = f("
	multi line \"string\"
	ending in slash \
", 1)\
```

See https://gist.github.com/cellularmitosis/6fd5fc2a65225364f72d3574abd9d5d5