### PR TITLE
Hide TypstCode syntax from menu

### DIFF
--- a/TypstCode.sublime-syntax
+++ b/TypstCode.sublime-syntax
@@ -8,6 +8,7 @@ name: Typst Code
 scope: source.typst
 version: 2
 extends: Packages/Typst/Typst.sublime-syntax
+hidden: true
 
 contexts:
   main:


### PR DESCRIPTION
I think the TypstCode syntax should be hidden from the menus (the command palette and the syntax selection menu from the bottom right corner) because this syntax is not meant to be selected manually.

And I don't know if the `typc` file extension really exists, but otherwise the following part is probably also unnecessary and could be removed (I haven't done it in this pull request because it's not so important):
```yaml
file_extensions:
  - typc
```
