### PR TITLE
Improve scopes for functions and builtins in math mode

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -166,8 +166,7 @@ contexts:
     - meta_scope: meta.code-fence.typst
     - include: fenced-syntaxes
     - include: fenced-raw
-    - match: ''
-      pop: true
+    - include: else-pop
 
   fenced-syntaxes:
     - include: fenced-actionscript
@@ -905,8 +904,7 @@ contexts:
     - match: '\['
       scope: punctuation.definition.generic.begin.typst
       push: ref-content
-    - match: ''
-      pop: true
+    - include: else-pop
 
   ref-content:
     - match: '\]'
@@ -928,13 +926,13 @@ contexts:
       scope: support.other.typst variable.function.typst
       captures:
         1: punctuation.definition.expression.typst
-        3: punctuation.accessor.typst
+        3: punctuation.accessor.dot.typst
       push: maybe-script-function-content
     - match: (#)(?!{{prefixes}})({{identifier}}(?:(\.){{identifier}})*)
       scope: meta.expression.typst constant.other.symbol.typst
       captures:
         1: punctuation.definition.variable.typst
-        3: punctuation.accessor.typst
+        3: punctuation.accessor.dot.typst
     - match: '{{markup_symbol_shorthands}}'
       scope: constant.other.typst
 
@@ -1013,14 +1011,14 @@ contexts:
       push: maybe-math-group
     - match: '(\.)?([[:alpha:]]{2,})'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: variable.function.math.typst
       push: maybe-math-group
 
   math-variables:
     - match: '(\.)?([[:alpha:]])'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: variable.other.math.typst
 
   maybe-math-group:
@@ -1243,18 +1241,17 @@ contexts:
     - meta_scope: meta.expression.typst
     - match: (?:(\.)({{identifier}}))?(\()
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
       push: script-function-params
     - match: (?:(\.)({{identifier}}))?(\[)
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
       push: content-block-content
-    - match: ''
-      pop: true
+    - include: else-pop
 
   # https://typst.app/docs/reference/foundations/regex
   # https://docs.rs/regex/latest/regex/#syntax
@@ -1296,13 +1293,13 @@ contexts:
   script-functions:
     - match: '(\.)?({{identifier}})(\()'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
       push: script-function-params
     - match: '(\.)?({{identifier}})(\[)'
       captures:
-        1: punctuation.accessor.typst
+        1: punctuation.accessor.dot.typst
         2: support.function.typst
         3: punctuation.section.group.begin.typst
       push: content-block-content

--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -959,7 +959,9 @@ contexts:
     - include: math-accent-functions
     - include: math-symbols
     - include: math-operators
+    - include: math-attachments
     - include: math-functions
+    - include: math-variables
     - include: symbols
     - include: strings
     - include: scripts
@@ -969,21 +971,21 @@ contexts:
       captures:
         1: support.function.math.typst
         2: punctuation.section.group.begin.typst
-      push: math-function-params
+      push: math-group-content
     - match: (dot)(?:(\.)(double|triple|quad))?(\()
       captures:
         1: support.function.math.typst
         2: punctuation.accessor.dot.typst
         3: support.function.math.modifier.typst
         4: punctuation.section.group.begin.typst
-      push: math-function-params
+      push: math-group-content
     - match: (acute)(?:(\.)(double))?(\()
       captures:
         1: support.function.math.typst
         2: punctuation.accessor.dot.typst
         3: support.function.math.modifier.typst
         4: punctuation.section.group.begin.typst
-      push: math-function-params
+      push: math-group-content
     - match: (arrow)(?:(\.)(l)(?:(\.)(r))?)?(\()
       captures:
         1: support.function.math.typst
@@ -992,52 +994,62 @@ contexts:
         4: punctuation.accessor.dot.typst
         5: support.function.math.modifier.typst
         6: punctuation.section.group.begin.typst
-      push: math-function-params
+      push: math-group-content
     - match: (harpoon)(?:(\.)(lt))?(\()
       captures:
         1: support.function.math.typst
         2: punctuation.accessor.dot.typst
         3: support.function.math.modifier.typst
         4: punctuation.section.group.begin.typst
-      push: math-function-params
+      push: math-group-content
 
   math-functions:
-    - match: '(\.)?([[:alpha:]]+)(\()'
-      captures:
-        1: punctuation.accessor.typst
-        2: support.function.math.typst
-        3: punctuation.section.group.begin.typst
-      push: math-function-params
+    - match: (?:dif|Dif){{break}}
+      scope: support.constant.math.typst
+    - match: (?:arccos|arcsin|arctan|arg|cos|cosh|cot|coth|csc|csch|ctg|deg|det|dim|exp|gcd|lcm|hom|id|im|inf|ker|lg|lim|liminf|limsup|ln|log|max|min|mod|Pr|sec|sech|sin|sinc|sinh|sup|tan|tanh|tg|tr){{break}}
+      scope: support.constant.math.operator.typst
+    - match: (?:abs|attach|bb|binom|bold|cal|cancel|cases|ceil|class|display|floor|frac|frak|inline|italic|limits|lr|mat|mid|mono|norm|op|overbrace|overbracket|overline|overparen|overshell|primes|root|round|sans|scripts?|serif|sqrt|sscript|stretch|underbrace|underbracket|underline|underparen|undershell|upright|vec)\b
+      scope: support.function.math.typst
+      push: maybe-math-group
     - match: '(\.)?([[:alpha:]]{2,})'
       captures:
         1: punctuation.accessor.typst
-        2: support.function.math.typst
+        2: variable.function.math.typst
+      push: maybe-math-group
+
+  math-variables:
     - match: '(\.)?([[:alpha:]])'
       captures:
         1: punctuation.accessor.typst
         2: variable.other.math.typst
 
-  math-brackets:
-    - match: '\('
-      scope: constant.character.parenthesis.typst
-      push: math-bracket-content
+  maybe-math-group:
+    - match: \(
+      scope: punctuation.section.group.begin.typst
+      set: math-group-content
+    - include: else-pop
 
-  math-bracket-content:
+  math-group-content:
     - match: (?=\$)
       pop: true
-    - match: (\))
-      captures:
-        1: constant.character.parenthesis.typst
+    - match: \)
+      scope: punctuation.section.group.end.typst
       pop: true
     - include: math-common
     - include: script-symbols
 
-  math-function-params:
+  math-brackets:
+    - match: \(
+      scope: constant.character.parenthesis.typst
+      push: math-brackets-content
+    - match: \)
+      scope: constant.character.parenthesis.typst
+
+  math-brackets-content:
     - match: (?=\$)
       pop: true
-    - match: (\))
-      captures:
-        1: punctuation.section.group.end.typst
+    - match: \)
+      scope: constant.character.parenthesis.typst
       pop: true
     - include: math-common
     - include: script-symbols
@@ -1092,8 +1104,13 @@ contexts:
         1: punctuation.definition.backslash.typst
 
   math-operators:
-    - match: \+|\-|=|-|\*|/|\^|_|<|>
+    - match: \+|\-|=|-|\*|/|<|>
       scope: keyword.operator.math.typst
+
+  math-attachments:
+    - match: \^|_
+      scope: keyword.operator.math.typst
+      push: maybe-math-group
 
 ###[ Scripting ]##############################################################
 
@@ -2053,8 +2070,6 @@ contexts:
             1: support.constant.sym.modifier.typst
             2: punctuation.accessor.dot.typst
         - include: consume-and-pop
-    - match: (?:dif|Dif){{break}}
-      scope: support.constant.math.typst
     - match: (?:AA|BB|CC|DD|EE|FF|GG|HH|II|JJ|KK|LL|MM|NN|OO|PP|QQ|RR|SS|TT|UU|VV|WW|XX|YY|ZZ){{break}}
       scope: support.constant.sym.typst
     - match: (?:Alpha|Beta|Chi|Delta|Epsilon|Eta|Gamma|Iota|Kai|Kappa|Lambda|Mu|Nu|Omega|Omicron|Phi|Pi|Psi|Rho|Sigma|Tau|Theta|Upsilon|Xi|Zeta|alpha|beta|chi|delta|epsilon|eta|gamma|iota|kappa|lambda|mu|nu|omega|omicron|phi|pi|psi|rho|sigma|tau|theta|upsilon|xi|zeta){{break}}

--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -19,7 +19,7 @@ variables:
   html_entity: '&([a-zA-Z0-9]+|#\d+|#[Xx]\h+);'
   no_escape_behind: '(?<![^\\]\\)(?<![\\]{3})'
   markup_symbol_shorthands: (\.\.\.|---?|-\?|~)
-  math_symbol_shorthands: (->>?|-->|::?=|!=|\[\||<==?>|<--?>|<--?|<-<|<<-|<<<?|<==?|<~~?|>->|>>>?|==?>|=:|>=|\|[-=]>|\|\]|\|\||~~?>|')
+  math_symbol_shorthands: (->>?|-->|::?=|!=|\[\||<==?>|<--?>|<--?|<-<|<<-|<<<?|<==?|<~~?|>->|>>>?|==?>|=:|>=|\*|\|[-=]>|\|\]|\|\||~~?>|')
   non_raw_ident: '[[:alpha:]][-_[:alnum:]]*|_[-_[:alnum:]]+'
   identifier: '(?:{{non_raw_ident}})'
   operators: ([+*/]=?|!=|\B-=?|=>|==?|[<>]=?|\bnot\s+in\b)
@@ -1103,7 +1103,7 @@ contexts:
         1: punctuation.definition.backslash.typst
 
   math-operators:
-    - match: \+|\-|=|-|\*|/|<|>
+    - match: \+|\-|/|=|<|>
       scope: keyword.operator.math.typst
 
   math-attachments:
@@ -1317,9 +1317,8 @@ contexts:
 
   script-function-params:
     - meta_scope: meta.function-call.arguments.typst
-    - match: (\))
-      captures:
-        1: punctuation.section.group.end.typst
+    - match: \)
+      scope: punctuation.section.group.end.typst
       pop: true
     - match: '({{identifier}})\s*(:)'
       captures:

--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -958,6 +958,8 @@ contexts:
     - include: math-symbols
     - include: math-operators
     - include: math-attachments
+    - include: math-punctuations
+    - include: math-spacings
     - include: math-functions
     - include: math-variables
     - include: symbols
@@ -1033,8 +1035,8 @@ contexts:
     - match: \)
       scope: punctuation.section.group.end.typst
       pop: true
-    - include: math-common
     - include: script-symbols
+    - include: math-common
 
   math-brackets:
     - match: \(
@@ -1050,7 +1052,6 @@ contexts:
       scope: constant.character.parenthesis.typst
       pop: true
     - include: math-common
-    - include: script-symbols
 
   math-numerics:
     - match: \b(0x)(\h+)
@@ -1109,6 +1110,16 @@ contexts:
     - match: \^|_
       scope: keyword.operator.math.typst
       push: maybe-math-group
+
+  math-punctuations:
+    - match: \,
+      scope: punctuation.separator.comma.typst
+    - match: ':'
+      scope: punctuation.separator.colon.typst
+
+  math-spacings:
+    - match: \b(?:thin|med|thick|quad|wide)\b
+      scope: support.constant.math.typst
 
 ###[ Scripting ]##############################################################
 

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -426,7 +426,7 @@ $#[Y] != #[X]$
 
 // #23
 #counter(page).update(1).bar
-//            ^ punctuation.accessor
+//            ^ punctuation.accessor.dot.typst
 //             ^^^^^^ support.function.typst
 //                      ^ - support.function
 

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -380,6 +380,11 @@ $ sum_(i=1)^(N-1) x_i $
 $ ) $
 //^ constant.character.parenthesis.typst
 
+$ bold(u): Omega -> RR^d, quad p: Omega -> RR $
+//       ^ punctuation.separator.colon.typst
+//                      ^ punctuation.separator.comma.typst
+//                        ^^^^ support.constant.math.typst
+
   #sym.phi.alt
 //^ punctuation.definition.expression.typst
 // ^^^ support.module.sym.typst

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -328,10 +328,6 @@ $ 2pi $
 //^ constant.numeric.value.typst
 // ^^ support.constant.sym.greek.typst
 
-$ sin x $
-//^^^ support.constant.math.operator.typst
-//    ^ variable.other.math.typst
-
 $ frac(x, y) $
 //^^^^ support.function.math.typst
 //    ^ punctuation.section.group.begin.typst

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -143,7 +143,7 @@ Left #h(1fr) Left-ish #h(2fr) Right
 
 $ sin pi => 0 $
 //^^^^^^^^^^^^^ markup.math.typst
-//^^^ support.function.math.typst
+//^^^ support.constant.math.operator.typst
 //    ^^ support.constant.sym.greek.typst
 //       ^^ constant.other.typst
 //          ^ constant.numeric.value.typst
@@ -328,9 +328,57 @@ $ 2pi $
 //^ constant.numeric.value.typst
 // ^^ support.constant.sym.greek.typst
 
-$ foo x $
-//^^^ support.function.math.typst
+$ sin x $
+//^^^ support.constant.math.operator.typst
 //    ^ variable.other.math.typst
+
+$ frac(x, y) $
+//^^^^ support.function.math.typst
+//    ^ punctuation.section.group.begin.typst
+//     ^ variable.other.math.typst
+//      ^ punctuation.separator.typst
+//        ^ variable.other.math.typst
+//         ^ punctuation.section.group.end.typst
+
+$ frac $
+//^^^^ support.function.math.typst
+
+$ foo(x) $
+//^^^ variable.function.math.typst
+//   ^ punctuation.section.group.begin.typst
+//    ^ variable.other.math.typst
+//     ^ punctuation.section.group.end.typst
+
+$ foo (x) $
+//^^^ variable.function.math.typst
+//    ^ constant.character.parenthesis.typst
+//     ^ variable.other.math.typst
+//      ^ constant.character.parenthesis.typst
+
+$ foo x $
+//^^^ variable.function.math.typst
+//    ^ variable.other.math.typst
+
+$ f(x) $
+//^ variable.other.math.typst
+// ^ constant.character.parenthesis.typst
+//  ^ variable.other.math.typst
+//   ^ constant.character.parenthesis.typst
+
+$ phi(x) $
+//^^^ support.constant.sym.greek.typst
+//   ^ constant.character.parenthesis.typst
+//    ^ variable.other.math.typst
+//     ^ constant.character.parenthesis.typst
+
+$ sum_(i=1)^(N-1) x_i $
+//    ^ punctuation.section.group.begin.typst
+//        ^ punctuation.section.group.end.typst
+//          ^ punctuation.section.group.begin.typst
+//              ^ punctuation.section.group.end.typst
+
+$ ) $
+//^ constant.character.parenthesis.typst
 
   #sym.phi.alt
 //^ punctuation.definition.expression.typst


### PR DESCRIPTION
This pull request includes several more or less independent changes. I hope it's okay to combine them into a single pull request.

1. Currently, all words in math mode that consists of multiple letters and are not one of the built-in symbol names added in #52 have the scope `support.function`. With this pull request, this scope is only applied to built-in functions like `round`, `abs`, ... and unknown words are considered to be user-defined functions that get the scope `variable.function`. This should make it easier to see what is a built-in function while typing, presuming that the color scheme uses different colors for these two scopes (which is for example the case in Mariana). I have also added the scope `support.constant` for a few other builtins (operator names like `sin` and spacings like `quad`).

2. Single letters in math mode are never scoped as functions, even if they are followed by a bracket. For example in `f(x)`.

3. If a subscript or superscript is followed by a bracket group, the brackets get `punctuation` scopes, for example in `sum_(i=1)^n`. The goal is to distinguish the brackets which are used for groupings and function calls to brackets which are actually printed in the PDF document (`constant.character`). For more details see the syntax tests that I added.
A different occasion where this unfortunately does not work is in fractions, for example `(a+b) / (c+d)`. Here the brackets get the `constant.character` scope, but they are not actually printed in the document. But I think it's not really possible to handle cases like this.

5. Added scopes for comma and colon symbols in math mode which had no scope before in some cases. Here I used `punctuation.separator` - perhaps it would be more consistent to use `constant.character` instead (?)

6. Changed the scope for the asterisk symbol `*` from `keyword.operator` to `constant.other`, because this is not the multiplication symbol (`dot`). In general I wonder if maybe the other printed operator symbols in math mode (`+ - = < >`) should also be changed from `keyword.operator` to either `constant.other` or `constant.character`, because they are just regular symbols that are printed in the PDF document. The slash `/` is maybe different, because it has special behavior and displays an actual fraction with a horizontal bar. So `/` is more like the sub- and superscript symbols `_ ^` which have special behavior, but are not printed in the document. Maybe it can be improved later.