### PR TITLE
Fix highlighting for integer numbers in subscript

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -1011,7 +1011,7 @@ contexts:
     - match: (?:abs|attach|bb|binom|bold|cal|cancel|cases|ceil|class|display|floor|frac|frak|inline|italic|limits|lr|mat|mid|mono|norm|op|overbrace|overbracket|overline|overparen|overshell|primes|root|round|sans|scripts?|serif|sqrt|sscript|stretch|underbrace|underbracket|underline|underparen|undershell|upright|vec)\b
       scope: support.function.math.typst
       push: maybe-math-group
-    - match: '(\.)?([[:alpha:]]{2,})'
+    - match: '(\.)?([[:alpha:]][[:alpha:]\d]+)'
       captures:
         1: punctuation.accessor.dot.typst
         2: variable.function.math.typst
@@ -1054,17 +1054,17 @@ contexts:
     - include: math-common
 
   math-numerics:
-    - match: \b(0x)(\h+)
+    - match: (0x)(\h+)
       scope: meta.number.integer.hexadecimal.typst
       captures:
         1: constant.numeric.base.typst
         2: constant.numeric.value.typst
-    - match: \b(0o)([0-7]+)
+    - match: (0o)([0-7]+)
       scope: meta.number.integer.octal.typst
       captures:
         1: constant.numeric.base.typst
         2: constant.numeric.value.typst
-    - match: \b(0b)([01]+)
+    - match: (0b)([01]+)
       scope: meta.number.integer.binary.typst
       captures:
         1: constant.numeric.base.typst
@@ -1075,7 +1075,7 @@ contexts:
         1: constant.numeric.value.typst
         2: punctuation.separator.decimal.typst
         3: constant.numeric.suffix.typst
-    - match: \b(\d+)(%|(?:pt|mm|cm|in|em|deg|rad|fr)\b)?
+    - match: (\d+)(%|(?:pt|mm|cm|in|em|deg|rad|fr)\b)?
       scope: meta.number.integer.decimal.typst
       captures:
         1: constant.numeric.value.typst

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -90,6 +90,12 @@ link: https://example.org?a=%20b
  #1e4
 //^^^ meta.number.float.decimal.typst constant.numeric.value.typst
 
+$ x_1, x^1, x_1.23, x^1.23 $
+//  ^ meta.number.integer.decimal.typst constant.numeric.value.typst
+//       ^ meta.number.integer.decimal.typst constant.numeric.value.typst
+//            ^^^^ meta.number.float.decimal.typst constant.numeric.value.typst
+//                    ^^^^ meta.number.float.decimal.typst constant.numeric.value.typst
+
 #rect(width: 72pt)
 //           ^^^^ meta.number.integer.decimal.typst
 //           ^^ constant.numeric.value.typst
@@ -354,6 +360,9 @@ $ foo (x) $
 $ foo x $
 //^^^ variable.function.math.typst
 //    ^ variable.other.math.typst
+
+$ foo1 $
+//^^^^ variable.function.math.typst - constant.numeric
 
 $ f(x) $
 //^ variable.other.math.typst


### PR DESCRIPTION
This pull request fixes highlighting for integer numbers in subscripts in math mode and for user-defined function names which contain numbers.