### PR TITLE
Add colon in syntax definition of labels and refs.

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -883,18 +883,18 @@ contexts:
       captures:
         1: punctuation.definition.escape.typst
 
-  # https://typst.app/docs/reference/construct/label
+  # https://typst.app/docs/reference/foundations/label
   labels:
-    - match: '(<)([-_\w]+)(>)'
+    - match: '(<)([-_:\w]+)(>)'
       scope: storage.modifier.label.typst
       captures:
         1: punctuation.definition.label.begin.typst
         2: entity.name.label.typst
         3: punctuation.definition.label.end.typst
 
-  # https://typst.app/docs/reference/meta/ref
+  # https://typst.app/docs/reference/model/ref
   refs:
-    - match: '(@)[-_\w]+'
+    - match: '(@)[-_:\w]+'
       scope: constant.other.reference.typst
       captures:
         1: punctuation.definition.reference.typst


### PR DESCRIPTION
I have kept the habit of writing my labels `fig:...` or `eq:...` as in LaTeX.
These two links to the Typst documentation were also broken.