### PR TITLE
Adjust word separators and spelling selector settings

### DIFF
--- a/Typst.sublime-settings
+++ b/Typst.sublime-settings
@@ -1,0 +1,4 @@
+{
+    "word_separators": "./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}`~?_",
+    "spelling_selector": "-(comment, markup.math, markup.raw, markup.underline.link, meta.expression, entity.name.label, constant), string.quoted - meta.expression",
+}


### PR DESCRIPTION
This adds `_` to the word separators setting, because this is used frequently in math mode for subscript. This affects what gets selected when you double click on a word or press <kbd>Ctrl</kbd>+<kbd>D</kbd>.

Also excludes various scopes from the spelling selector setting, which is used for the spell check functionality (`View > Spell Check`).