### PR TITLE
Assign scope for single @ symbol to make auto-complete possible

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -899,6 +899,8 @@ contexts:
       captures:
         1: punctuation.definition.reference.typst
       push: maybe-ref-content
+    - match: '@'
+      scope: punctuation.definition.reference.typst
 
   maybe-ref-content:
     - match: '\['

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -281,6 +281,9 @@ Evil purple now occurs <<<
 //^ punctuation.definition.reference.typst
 // ^^^^^ - punctuation 
 
+  @
+//^ punctuation.definition.reference.typst
+
 $ F_n = round(1 / sqrt(5) phi.alt^n) $
 //^ variable.other.math.typst
 // ^ keyword.operator.math.typst


### PR DESCRIPTION
This allows to add this particular scope to the auto-complete selector. I would like to use this to improve auto-completion behavior when using a language server.