### PR TITLE
Fix scope for ellipsis symbol in math function

### DIFF
--- a/Typst.sublime-syntax
+++ b/Typst.sublime-syntax
@@ -1056,8 +1056,8 @@ contexts:
       captures:
         1: variable.parameter.typst
         2: punctuation.separator.key-value.typst
-    - include: script-symbols
     - include: math-common
+    - include: script-symbols
 
   math-brackets:
     - match: \(
@@ -1248,7 +1248,7 @@ contexts:
     - match: ':'
       scope: punctuation.separator.key-value.typst
     - match: ','
-      scope: punctuation.separator.typst
+      scope: punctuation.separator.comma.typst
     - match: ';'
       scope: punctuation.terminator.typst
     - match: '\.\.'

--- a/syntax_test_typst.typ
+++ b/syntax_test_typst.typ
@@ -362,7 +362,7 @@ $ frac(x, y) $
 //^^^^ support.function.math.typst
 //    ^ punctuation.section.group.begin.typst
 //     ^ variable.other.math.typst
-//      ^ punctuation.separator.typst
+//      ^ punctuation.separator.comma.typst
 //        ^ variable.other.math.typst
 //         ^ punctuation.section.group.end.typst
 
@@ -412,6 +412,9 @@ $ mat(1, 2; 3, 4; delim: "[") $
 //                ^^^^^ variable.parameter.typst
 //                     ^ punctuation.separator.key-value.typst
 //                           ^ - meta.function-call.arguments
+
+$ mat(1, ..., n; 1, ..., n) $
+//       ^^^ constant.other.typst - keyword.operator.range
 
 $ ) $
 //^ constant.character.parenthesis.typst


### PR DESCRIPTION
Fix a regression from https://github.com/hyrious/typst-syntax-highlight/commit/7b5d83581914e0939e2bcd32cc62c9a75b4f2306 by reverting the include priority.