### PR TITLE
Try to fix scope for spelling

### DIFF
--- a/Typst.sublime-settings
+++ b/Typst.sublime-settings
@@ -1,4 +1,4 @@
 {
     "word_separators": "./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}`~?_",
-    "spelling_selector": "-(comment, markup.math, markup.raw, markup.underline.link, meta.expression, entity.name.label, constant), string.quoted - meta.expression",
+    "spelling_selector": "-(comment, markup.math, markup.raw, markup.underline.link, variable.parameter, variable.function, support.function.typst, entity.name.label, constant), string.quoted - meta.expression",
 }


### PR DESCRIPTION
The `meta.expression` was to generic and prevented a lot of detections in spell checking, particularly in captions.
I tried to replace it by some edge cases, like function call/definition and variable parameter.
It is certainly not perfect (I do not know much about it), but I reckon it is better to have some false positive, rather than the opposite. 
Feel free to improve it.

Before:
<img width="119" height="145" alt="Capture d’écran du 2025-10-13 14-04-49" src="https://github.com/user-attachments/assets/824e3c1a-6f7e-4323-80f0-1949c3a11361" />

After:
<img width="112" height="145" alt="Capture d’écran du 2025-10-13 14-05-07" src="https://github.com/user-attachments/assets/0875a82d-e278-4910-9e2b-32a3b9efea7b" />
