### PR TITLE
Fix regex for error messages on Windows

### DIFF
--- a/Typst.sublime-build
+++ b/Typst.sublime-build
@@ -1,7 +1,7 @@
 {
   "cmd": ["typst", "compile", "$file"],
   "selector": "text.typst",
-  "file_regex": "┌─ (...*?):([0-9]*):?([0-9]*)",
+  "file_regex": "┌─ (?:\\\\{2}\\?\\\\)?(.+):(\\d+):(\\d+)",
   "env": { "NO_COLOR": "1" },
   "cancel": { "kill": true },
   "variants": [


### PR DESCRIPTION
On Windows, filepaths in error messages are prefixed with `\\?\` (see https://github.com/typst/typst/issues/7143), so jumping to errors currently doesn't work and the error annotations are not shown when there are build errors. This modification for the `file_regex` should make it work on Windows (note that I have not tested on Mac or Linux, but I believe it should still work).

Example:
```typst
== Example document

$ A plus.circle B $

$ A foo B $
```

```
warning: `plus.circle` is deprecated, use `plus.o` instead
  ┌─ \\?\D:\typst\test.typ:3:9
  │
3 │ $ A plus.circle B $
  │          ^^^^^^

error: unknown variable: foo
  ┌─ \\?\D:\typst\test.typ:5:4
  │
5 │ $ A foo B $
  │     ^^^
  │
  = hint: if you meant to display multiple letters as is, try adding spaces between each letter: `f o o`
  = hint: or if you meant to display this as text, try placing it in quotes: `"foo"`
```