### PR TITLE
Add syntax for build results

### DIFF
--- a/Build Results.sublime-syntax
+++ b/Build Results.sublime-syntax
@@ -1,0 +1,55 @@
+%YAML 1.2
+---
+name: Typst Build Results
+hidden: true
+scope: text.build-results.typst
+
+contexts:
+  main:
+    - match: '^((error)(:)).*(\n)'
+      scope: message.error.build-results
+      captures:
+        1: markup.heading.build-results
+        2: markup.error.build-results
+        3: punctuation.separator.build-results
+        4: meta.fold.begin.build-results
+      push:
+        - include: fold-end
+        - include: location
+        - include: line-number
+        - match: '^\s*│\s*(\^+)'
+          captures:
+            1: markup.error.build-results
+    - match: '^((warning)(:)).*(\n)'
+      scope: message.warning.build-results
+      captures:
+        1: markup.heading.build-results
+        2: markup.warning.build-results
+        3: punctuation.separator.build-results
+        4: meta.fold.begin.build-results
+      push:
+        - include: fold-end
+        - include: location
+        - include: line-number
+        - match: '^\s*│\s*(\^+)'
+          captures:
+            1: markup.warning.build-results
+
+  fold-end:
+    - match: ^\n
+      scope: meta.fold.end.build-results
+      pop: 1
+
+  location:
+    - match: '^\s*┌─ (?:\\{2}\?\\)?(.+)(:)(\d+)(:)(\d+)'
+      captures:
+        1: entity.name.filename.build-results
+        2: punctuation.separator.sequence.build-results
+        3: constant.numeric.line-number.build-results
+        4: punctuation.separator.sequence.build-results
+        5: constant.numeric.line-number.build-results
+
+  line-number:
+    - match: '^(\d+)\s*│'
+      captures:
+        1: constant.numeric.line-number.build-results

--- a/Typst.sublime-build
+++ b/Typst.sublime-build
@@ -4,6 +4,7 @@
   "file_regex": "┌─ (?:\\\\{2}\\?\\\\)?(.+):(\\d+):(\\d+)",
   "env": { "NO_COLOR": "1" },
   "cancel": { "kill": true },
+  "syntax": "Packages/Typst/Build Results.sublime-syntax",
   "variants": [
     {
       "name": "Open",


### PR DESCRIPTION
Just an idea: it adds basic highlighting for errors and warnings in the build results output:

<img width="720" height="288" alt="build_results" src="https://github.com/user-attachments/assets/96591085-0bf6-45b1-bdb1-a92fd0552537" />
