### PR TITLE
Improve scope spelling

### DIFF
--- a/Typst.sublime-settings
+++ b/Typst.sublime-settings
@@ -1,4 +1,4 @@
 {
     "word_separators": "./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}`~?_",
-    "spelling_selector": "-(comment, markup.math, markup.raw, markup.underline.link, variable.parameter, variable.function, support, keyword.declaration, entity.name.label, constant), string.quoted - meta.expression",
+    "spelling_selector": "-(comment, constant, entity.name.label, keyword.declaration, markup.math, markup.raw, markup.underline.link, support, variable.function, variable.parameter), string.quoted - meta.expression",
 }

--- a/Typst.sublime-settings
+++ b/Typst.sublime-settings
@@ -1,4 +1,4 @@
 {
     "word_separators": "./\\()\"'-:,.;<>~!@#$%^&*|+=[]{}`~?_",
-    "spelling_selector": "-(comment, markup.math, markup.raw, markup.underline.link, variable.parameter, variable.function, support.function.typst, entity.name.label, constant), string.quoted - meta.expression",
+    "spelling_selector": "-(comment, markup.math, markup.raw, markup.underline.link, variable.parameter, variable.function, support, keyword.declaration, entity.name.label, constant), string.quoted - meta.expression",
 }


### PR DESCRIPTION
An improvement of #63 that removes some false positive.

Before:
<img width="119" height="177" alt="Capture d’écran du 2025-10-16 17-42-06" src="https://github.com/user-attachments/assets/1f0a056d-de9c-42a6-a361-2bb19e0a5e82" />

After:
<img width="113" height="170" alt="Capture d’écran du 2025-10-16 17-42-25" src="https://github.com/user-attachments/assets/0541bdfb-9e6c-4d6d-957c-5dfb8dd27577" />
