### PR TITLE
fix highlighting of typ/typm/typc

### DIFF
--- a/TypstCodeSyntaxes.sublime-syntax
+++ b/TypstCodeSyntaxes.sublime-syntax
@@ -1,6 +1,5 @@
 %YAML 1.2
 ---
-scope: text.typst
 version: 2
 hidden: true
 

--- a/gen/src/main.rs
+++ b/gen/src/main.rs
@@ -9,7 +9,6 @@ use typst_library::text::RAW_SYNTAXES;
 const HEADER: &str = r#"
 %YAML 1.2
 ---
-scope: text.typst
 version: 2
 hidden: true
 


### PR DESCRIPTION
<details><summary>before/after</summary>
<p>

<img width="651" height="377" alt="image" src="https://github.com/user-attachments/assets/b74e2469-6415-49ed-91ee-4b4e991908c1" />

<img width="649" height="505" alt="image" src="https://github.com/user-attachments/assets/bd18af04-b6ab-4489-bc48-2f09167d26fd" />


</p>
</details> 